### PR TITLE
Use native enum "ImportForeignSchemaType"

### DIFF
--- a/packages/ast/deploy/schemas/deparser/procedures/deparse.sql
+++ b/packages/ast/deploy/schemas/deparser/procedures/deparse.sql
@@ -5150,11 +5150,11 @@ BEGIN
 
     -- table filtering rules
     IF (node->'list_type' IS NOT NULL AND jsonb_array_length(node->'table_list') > 0) THEN
-      IF (node->>'list_type' = 'LIMIT_TO') THEN
+      IF (node->>'list_type' = 'FDW_IMPORT_SCHEMA_LIMIT_TO') THEN
         output = array_append(output, 'LIMIT TO');
-      ELSEIF (node->>'list_type' = 'EXCEPT') THEN
+      ELSEIF (node->>'list_type' = 'FDW_IMPORT_SCHEMA_EXCEPT') THEN
         output = array_append(output, 'EXCEPT');
-      ELSE
+      ELSEIF (node->>'list_type' <> 'FDW_IMPORT_SCHEMA_ALL') THEN
         RAISE EXCEPTION 'BAD_EXPRESSION %', 'ImportForeignSchemaStmt (ListType)';
       END IF;
 

--- a/packages/ast/sql/ast--13.0.3.sql
+++ b/packages/ast/sql/ast--13.0.3.sql
@@ -7285,18 +7285,18 @@ BEGIN
         END IF;
 
         RETURN array_to_string(output, ' ');
+
+      ELSIF (node->'arg' IS NOT NULL) THEN
+        RETURN defname || ' ' || deparser.expression(node->'arg', jsonb_set(context, '{simple}', to_jsonb(TRUE)));
       END IF;
-    END IF;
-
-    IF ((context->'option')::bool IS TRUE) THEN
+    ELSIF ((context->'foreignSchema')::bool IS TRUE) THEN
       RETURN format('%s ''%s''', defname, deparser.expression(node->'arg', jsonb_set(context, '{simple}', to_jsonb(TRUE))));
+
+    ELSE
+        RETURN defname || '=' || deparser.expression(node->'arg');
     END IF;
 
-    IF (node->'arg' IS NOT NULL) THEN
-      RETURN defname || '=' || deparser.expression(node->'arg');
-    ELSE
-      RETURN defname;
-    END IF;
+    RETURN defname;
 END;
 $EOFCODE$ LANGUAGE plpgsql IMMUTABLE;
 
@@ -10032,11 +10032,11 @@ BEGIN
 
     -- table filtering rules
     IF (node->'list_type' IS NOT NULL AND jsonb_array_length(node->'table_list') > 0) THEN
-      IF (node->>'list_type' = 'LIMIT_TO') THEN
+      IF (node->>'list_type' = 'FDW_IMPORT_SCHEMA_LIMIT_TO') THEN
         output = array_append(output, 'LIMIT TO');
-      ELSEIF (node->>'list_type' = 'EXCEPT') THEN
+      ELSEIF (node->>'list_type' = 'FDW_IMPORT_SCHEMA_EXCEPT') THEN
         output = array_append(output, 'EXCEPT');
-      ELSE
+      ELSEIF (node->>'list_type' <> 'FDW_IMPORT_SCHEMA_ALL') THEN
         RAISE EXCEPTION 'BAD_EXPRESSION %', 'ImportForeignSchemaStmt (ListType)';
       END IF;
 
@@ -10054,7 +10054,7 @@ BEGIN
     IF (node->'options') IS NOT NULL THEN
       output = array_append(output, 'OPTIONS');
       output = array_append(output, deparser.parens(
-        deparser.list(node->'options', ', ', jsonb_set(context, '{option}', to_jsonb(TRUE)))
+        deparser.list(node->'options', ', ', jsonb_set(context, '{foreignSchema}', to_jsonb(TRUE)))
       ));
     END IF;
 

--- a/packages/ast/test/__tests__/sandbox/__snapshots__/foreign-schema.test.js.snap
+++ b/packages/ast/test/__tests__/sandbox/__snapshots__/foreign-schema.test.js.snap
@@ -1,3 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`empty 1`] = `"IMPORT FOREIGN SCHEMA \\"HumanResources\\" LIMIT TO (\\"Employee\\", \\"Shift\\") FROM SERVER mssqldb INTO pg_temp OPTIONS (import_default 'false', import_not_null 'true')"`;
+exports[`simple 1`] = `"IMPORT FOREIGN SCHEMA my_rschema FROM SERVER my_fserv INTO my_schema"`;
+
+exports[`with_except 1`] = `"IMPORT FOREIGN SCHEMA my_rschema EXCEPT (table_1, table_2) FROM SERVER my_fserv INTO my_schema"`;
+
+exports[`with_limit_and_options 1`] = `"IMPORT FOREIGN SCHEMA my_rschema LIMIT TO (table_1, table_2) FROM SERVER my_fserv INTO my_schema OPTIONS (option_1 'false', option_2 'true')"`;

--- a/packages/ast/test/__tests__/sandbox/foreign-schema.test.js
+++ b/packages/ast/test/__tests__/sandbox/foreign-schema.test.js
@@ -19,26 +19,64 @@ afterAll(async () => {
   } catch (e) {}
 });
 
-it('empty', async () => {
+it('simple', async () => {
   const [{ deparse: result }] = await db.any(
     `
     select deparser.deparse(
         ast.import_foreign_schema_stmt(
-            v_server_name := 'mssqldb',
-            v_remote_schema := 'HumanResources',
-            v_local_schema := 'pg_temp',
-            v_list_type := 'LIMIT_TO',
+          v_server_name := 'my_fserv',
+          v_remote_schema := 'my_rschema',
+          v_local_schema := 'my_schema',
+          v_list_type := 'FDW_IMPORT_SCHEMA_ALL'
+        )
+    );`,
+    []
+  );
+
+  expect(result).toMatchSnapshot();
+});
+
+it('with_except', async () => {
+  const [{ deparse: result }] = await db.any(
+    `
+    select deparser.deparse(
+        ast.import_foreign_schema_stmt(
+          v_server_name := 'my_fserv',
+          v_remote_schema := 'my_rschema',
+          v_local_schema := 'my_schema',
+          v_list_type := 'FDW_IMPORT_SCHEMA_EXCEPT',
+          v_table_list := to_jsonb(ARRAY[
+            ast.string('table_1'), 
+            ast.string('table_2')]
+          )
+        )
+    );`,
+    []
+  );
+
+  expect(result).toMatchSnapshot();
+});
+
+it('with_limit_and_options', async () => {
+  const [{ deparse: result }] = await db.any(
+    `
+    select deparser.deparse(
+        ast.import_foreign_schema_stmt(
+            v_server_name := 'my_fserv',
+            v_remote_schema := 'my_rschema',
+            v_local_schema := 'my_schema',
+            v_list_type := 'FDW_IMPORT_SCHEMA_LIMIT_TO',
             v_table_list := to_jsonb(ARRAY[
-              ast.string('Employee'), 
-              ast.string('Shift')]
+              ast.string('table_1'), 
+              ast.string('table_2')]
             ),
             v_options := to_jsonb(ARRAY[
                 ast.def_elem(
-                    v_defname := 'import_default',
+                    v_defname := 'option_1',
                     v_arg := ast.string('false')
                 ),
                 ast.def_elem(
-                    v_defname := 'import_not_null',
+                    v_defname := 'option_2',
                     v_arg := ast.string('true')
                 )
             ])


### PR DESCRIPTION
Hi,

I bring a complement PR to supplent #5 

* Use native enum "ImportForeignSchemaType" as defined in [pgsql-parser](https://github.com/pyramation/pgsql-parser/blob/master/packages/enums/src/enum.2str.json#L351)
* Add two more test cases
* Build the ast--*.sql file

Regards