### PR TITLE
Fix quotes for index names

### DIFF
--- a/packages/ast/deploy/schemas/deparser/procedures/deparse.sql
+++ b/packages/ast/deploy/schemas/deparser/procedures/deparse.sql
@@ -3107,9 +3107,8 @@ BEGIN
       output = array_append(output, 'CONCURRENTLY');
     END IF;
     
-    IF (node->'idxname' IS NOT NULL) THEN 
-      -- TODO needs quote?
-      output = array_append(output, node->>'idxname');
+    IF (node->'idxname' IS NOT NULL) THEN
+      output = array_append(output, quote_ident(node->>'idxname'));
     END IF;
 
     output = array_append(output, 'ON');
@@ -3122,12 +3121,12 @@ BEGIN
     END IF;
 
     IF (node->'indexParams' IS NOT NULL AND jsonb_array_length(node->'indexParams') > 0) THEN 
-      output = array_append(output, deparser.parens(deparser.list(node->'indexParams')));
+      output = array_append(output, deparser.parens(deparser.list_quotes(node->'indexParams')));
     END IF; 
 
     IF (node->'indexIncludingParams' IS NOT NULL AND jsonb_array_length(node->'indexIncludingParams') > 0) THEN 
       output = array_append(output, 'INCLUDE');
-      output = array_append(output, deparser.parens(deparser.list(node->'indexIncludingParams')));
+      output = array_append(output, deparser.parens(deparser.list_quotes(node->'indexIncludingParams')));
     END IF; 
 
     IF (node->'whereClause' IS NOT NULL) THEN 

--- a/packages/ast/sql/ast--13.0.4.sql
+++ b/packages/ast/sql/ast--13.0.4.sql
@@ -8216,9 +8216,8 @@ BEGIN
       output = array_append(output, 'CONCURRENTLY');
     END IF;
     
-    IF (node->'idxname' IS NOT NULL) THEN 
-      -- TODO needs quote?
-      output = array_append(output, node->>'idxname');
+    IF (node->'idxname' IS NOT NULL) THEN
+      output = array_append(output, quote_ident(node->>'idxname'));
     END IF;
 
     output = array_append(output, 'ON');
@@ -8231,12 +8230,12 @@ BEGIN
     END IF;
 
     IF (node->'indexParams' IS NOT NULL AND jsonb_array_length(node->'indexParams') > 0) THEN 
-      output = array_append(output, deparser.parens(deparser.list(node->'indexParams')));
+      output = array_append(output, deparser.parens(deparser.list_quotes(node->'indexParams')));
     END IF; 
 
     IF (node->'indexIncludingParams' IS NOT NULL AND jsonb_array_length(node->'indexIncludingParams') > 0) THEN 
       output = array_append(output, 'INCLUDE');
-      output = array_append(output, deparser.parens(deparser.list(node->'indexIncludingParams')));
+      output = array_append(output, deparser.parens(deparser.list_quotes(node->'indexIncludingParams')));
     END IF; 
 
     IF (node->'whereClause' IS NOT NULL) THEN 

--- a/packages/ast/test/__tests__/expressions/__fixtures__/indexes.js
+++ b/packages/ast/test/__tests__/expressions/__fixtures__/indexes.js
@@ -1,0 +1,169 @@
+export const indexes = [
+{
+    "RawStmt": {
+    "stmt": {
+        "IndexStmt": {
+        "idxname": "idx_simple",
+        "relation": {
+            "relname": "table_simple",
+            "inh": true,
+            "relpersistence": "p",
+            "location": 27
+        },
+        "accessMethod": "btree",
+        "indexParams": [
+            {
+            "IndexElem": {
+                "name": "simple",
+                "ordering": "SORTBY_DEFAULT",
+                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
+            }
+            }
+        ]
+        }
+    },
+    "stmt_len": 48,
+    "stmt_location": 0
+    }
+},
+{
+    "RawStmt": {
+    "stmt": {
+        "IndexStmt": {
+        "idxname": "idx_composite",
+        "relation": {
+            "relname": "table_composite",
+            "inh": true,
+            "relpersistence": "p",
+            "location": 80
+        },
+        "accessMethod": "btree",
+        "indexParams": [
+            {
+            "IndexElem": {
+                "name": "col1",
+                "ordering": "SORTBY_DEFAULT",
+                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
+            }
+            },
+            {
+            "IndexElem": {
+                "name": "col2",
+                "ordering": "SORTBY_DEFAULT",
+                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
+            }
+            }
+        ]
+        }
+    },
+    "stmt_len": 59,
+    "stmt_location": 49
+    }
+},
+{
+    "RawStmt": {
+    "stmt": {
+        "IndexStmt": {
+        "idxname": "idx_include",
+        "relation": {
+            "relname": "table_include",
+            "inh": true,
+            "relpersistence": "p",
+            "location": 138
+        },
+        "accessMethod": "btree",
+        "indexParams": [
+            {
+            "IndexElem": {
+                "name": "col1",
+                "ordering": "SORTBY_DEFAULT",
+                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
+            }
+            }
+        ],
+        "indexIncludingParams": [
+            {
+            "IndexElem": {
+                "name": "col2",
+                "ordering": "SORTBY_DEFAULT",
+                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
+            }
+            },
+            {
+            "IndexElem": {
+                "name": "col3",
+                "ordering": "SORTBY_DEFAULT",
+                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
+            }
+            }
+        ]
+        }
+    },
+    "stmt_len": 70,
+    "stmt_location": 109
+    }
+},
+{
+    "RawStmt": {
+    "stmt": {
+        "IndexStmt": {
+        "idxname": "idx_CaseSimple",
+        "relation": {
+            "relname": "Table_CaseSimple",
+            "inh": true,
+            "relpersistence": "p",
+            "location": 214
+        },
+        "accessMethod": "btree",
+        "indexParams": [
+            {
+            "IndexElem": {
+                "name": "CaseSimple",
+                "ordering": "SORTBY_DEFAULT",
+                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
+            }
+            }
+        ]
+        }
+    },
+    "stmt_len": 67,
+    "stmt_location": 180
+    }
+},
+{
+    "RawStmt": {
+    "stmt": {
+        "IndexStmt": {
+        "idxname": "idx_CaseInclude",
+        "relation": {
+            "relname": "table_caseinclude",
+            "inh": true,
+            "relpersistence": "p",
+            "location": 283
+        },
+        "accessMethod": "btree",
+        "indexParams": [
+            {
+            "IndexElem": {
+                "name": "simple",
+                "ordering": "SORTBY_DEFAULT",
+                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
+            }
+            }
+        ],
+        "indexIncludingParams": [
+            {
+            "IndexElem": {
+                "name": "CaseInclude",
+                "ordering": "SORTBY_DEFAULT",
+                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
+            }
+            }
+        ]
+        }
+    },
+    "stmt_len": 85,
+    "stmt_location": 248
+    }
+}
+];

--- a/packages/ast/test/__tests__/expressions/__snapshots__/indexes.test.js.snap
+++ b/packages/ast/test/__tests__/expressions/__snapshots__/indexes.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`index_stmt 1`] = `"CREATE INDEX idx_simple ON table_simple (simple);"`;
+
+exports[`index_stmt 2`] = `"CREATE INDEX idx_composite ON table_composite (col1, col2);"`;
+
+exports[`index_stmt 3`] = `"CREATE INDEX idx_include ON table_include (col1) INCLUDE (col2, col3);"`;
+
+exports[`index_stmt 4`] = `"CREATE INDEX \\"idx_CaseSimple\\" ON \\"Table_CaseSimple\\" (\\"CaseSimple\\");"`;
+
+exports[`index_stmt 5`] = `"CREATE INDEX \\"idx_CaseInclude\\" ON table_caseinclude (simple) INCLUDE (\\"CaseInclude\\");"`;

--- a/packages/ast/test/__tests__/expressions/indexes.test.js
+++ b/packages/ast/test/__tests__/expressions/indexes.test.js
@@ -1,0 +1,35 @@
+import { getConnections } from '../../utils';
+import { indexes } from './__fixtures__/indexes';
+
+let db, teardown;
+const objs = {
+  tables: {}
+};
+
+beforeAll(async () => {
+  ({ db, teardown } = await getConnections());
+  await db.begin();
+  await db.savepoint();
+});
+afterAll(async () => {
+  try {
+    //try catch here allows us to see the sql parsing issues!
+    await db.rollback();
+    await db.commit();
+    await teardown();
+  } catch (e) {}
+});
+
+it('index_stmt', async () => {
+    for (const index of indexes) {
+      const [{ deparse: result }] = await db.any(
+        `
+  select deparser.deparse(
+    $1::jsonb
+  );
+    `,
+        [index]
+      );
+      expect(result).toMatchSnapshot();
+    }
+  });


### PR DESCRIPTION
Hi,

Indexes are case-sensitives in PostgreSQL, I fixed _todo_ in `deparser.index_stmt()`

* quotes for indexes
* quotes for columns indexed
* quotes for columns included

Here a example when quotes are necessary:

```
regress=# \di "Sales"."IX_Store_SalesPersonID"
                     List of relations
 Schema |          Name          | Type  |  Owner  | Table
--------+------------------------+-------+---------+-------
 Sales  | IX_Store_SalesPersonID | index | regress | Store
(1 row)

regress=# CREATE INDEX IX_Store_SalesPersonID ON "Sales"."Store" (SalesPersonID);
ERROR:  column "salespersonid" does not exist

regress=# CREATE INDEX IX_Store_SalesPersonID ON "Sales"."Store" ("SalesPersonID");
CREATE INDEX

regress=# \di "Sales".*
                     List of relations
 Schema |          Name          | Type  |  Owner  | Table
--------+------------------------+-------+---------+-------
 Sales  | IX_Store_SalesPersonID | index | regress | Store
 Sales  | ix_store_salespersonid | index | regress | Store
(2 rows)
```