### PR TITLE
Fix quotes for index names (reviewed)

### DIFF
--- a/packages/ast/deploy/schemas/deparser/procedures/deparse.sql
+++ b/packages/ast/deploy/schemas/deparser/procedures/deparse.sql
@@ -2780,7 +2780,7 @@ BEGIN
     node = node->'IndexElem';
 
     IF (node->'name' IS NOT NULL) THEN
-      RETURN node->>'name';
+      RETURN quote_ident(node->>'name');
     END IF;
 
     IF (node->'expr' IS NOT NULL) THEN
@@ -3134,12 +3134,12 @@ BEGIN
     END IF;
 
     IF (node->'indexParams' IS NOT NULL AND jsonb_array_length(node->'indexParams') > 0) THEN 
-      output = array_append(output, deparser.parens(deparser.list_quotes(node->'indexParams')));
+      output = array_append(output, deparser.parens(deparser.list(node->'indexParams')));
     END IF; 
 
     IF (node->'indexIncludingParams' IS NOT NULL AND jsonb_array_length(node->'indexIncludingParams') > 0) THEN 
       output = array_append(output, 'INCLUDE');
-      output = array_append(output, deparser.parens(deparser.list_quotes(node->'indexIncludingParams')));
+      output = array_append(output, deparser.parens(deparser.list(node->'indexIncludingParams')));
     END IF; 
 
     IF (node->'whereClause' IS NOT NULL) THEN 

--- a/packages/ast/deploy/schemas/deparser/procedures/deparse.sql
+++ b/packages/ast/deploy/schemas/deparser/procedures/deparse.sql
@@ -3120,9 +3120,8 @@ BEGIN
       output = array_append(output, 'CONCURRENTLY');
     END IF;
     
-    IF (node->'idxname' IS NOT NULL) THEN 
-      -- TODO needs quote?
-      output = array_append(output, node->>'idxname');
+    IF (node->'idxname' IS NOT NULL) THEN
+      output = array_append(output, quote_ident(node->>'idxname'));
     END IF;
 
     output = array_append(output, 'ON');
@@ -3135,12 +3134,12 @@ BEGIN
     END IF;
 
     IF (node->'indexParams' IS NOT NULL AND jsonb_array_length(node->'indexParams') > 0) THEN 
-      output = array_append(output, deparser.parens(deparser.list(node->'indexParams')));
+      output = array_append(output, deparser.parens(deparser.list_quotes(node->'indexParams')));
     END IF; 
 
     IF (node->'indexIncludingParams' IS NOT NULL AND jsonb_array_length(node->'indexIncludingParams') > 0) THEN 
       output = array_append(output, 'INCLUDE');
-      output = array_append(output, deparser.parens(deparser.list(node->'indexIncludingParams')));
+      output = array_append(output, deparser.parens(deparser.list_quotes(node->'indexIncludingParams')));
     END IF; 
 
     IF (node->'whereClause' IS NOT NULL) THEN 

--- a/packages/ast/sql/ast--13.0.4.sql
+++ b/packages/ast/sql/ast--13.0.4.sql
@@ -7909,7 +7909,7 @@ BEGIN
     node = node->'IndexElem';
 
     IF (node->'name' IS NOT NULL) THEN
-      RETURN node->>'name';
+      RETURN quote_ident(node->>'name');
     END IF;
 
     IF (node->'expr' IS NOT NULL) THEN
@@ -8243,12 +8243,12 @@ BEGIN
     END IF;
 
     IF (node->'indexParams' IS NOT NULL AND jsonb_array_length(node->'indexParams') > 0) THEN 
-      output = array_append(output, deparser.parens(deparser.list_quotes(node->'indexParams')));
+      output = array_append(output, deparser.parens(deparser.list(node->'indexParams')));
     END IF; 
 
     IF (node->'indexIncludingParams' IS NOT NULL AND jsonb_array_length(node->'indexIncludingParams') > 0) THEN 
       output = array_append(output, 'INCLUDE');
-      output = array_append(output, deparser.parens(deparser.list_quotes(node->'indexIncludingParams')));
+      output = array_append(output, deparser.parens(deparser.list(node->'indexIncludingParams')));
     END IF; 
 
     IF (node->'whereClause' IS NOT NULL) THEN 

--- a/packages/ast/sql/ast--13.0.4.sql
+++ b/packages/ast/sql/ast--13.0.4.sql
@@ -8229,9 +8229,8 @@ BEGIN
       output = array_append(output, 'CONCURRENTLY');
     END IF;
     
-    IF (node->'idxname' IS NOT NULL) THEN 
-      -- TODO needs quote?
-      output = array_append(output, node->>'idxname');
+    IF (node->'idxname' IS NOT NULL) THEN
+      output = array_append(output, quote_ident(node->>'idxname'));
     END IF;
 
     output = array_append(output, 'ON');
@@ -8244,12 +8243,12 @@ BEGIN
     END IF;
 
     IF (node->'indexParams' IS NOT NULL AND jsonb_array_length(node->'indexParams') > 0) THEN 
-      output = array_append(output, deparser.parens(deparser.list(node->'indexParams')));
+      output = array_append(output, deparser.parens(deparser.list_quotes(node->'indexParams')));
     END IF; 
 
     IF (node->'indexIncludingParams' IS NOT NULL AND jsonb_array_length(node->'indexIncludingParams') > 0) THEN 
       output = array_append(output, 'INCLUDE');
-      output = array_append(output, deparser.parens(deparser.list(node->'indexIncludingParams')));
+      output = array_append(output, deparser.parens(deparser.list_quotes(node->'indexIncludingParams')));
     END IF; 
 
     IF (node->'whereClause' IS NOT NULL) THEN 

--- a/packages/ast/test/__tests__/expressions/__fixtures__/indexes.js
+++ b/packages/ast/test/__tests__/expressions/__fixtures__/indexes.js
@@ -1,0 +1,169 @@
+export const indexes = [
+{
+    "RawStmt": {
+    "stmt": {
+        "IndexStmt": {
+        "idxname": "idx_simple",
+        "relation": {
+            "relname": "table_simple",
+            "inh": true,
+            "relpersistence": "p",
+            "location": 27
+        },
+        "accessMethod": "btree",
+        "indexParams": [
+            {
+            "IndexElem": {
+                "name": "simple",
+                "ordering": "SORTBY_DEFAULT",
+                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
+            }
+            }
+        ]
+        }
+    },
+    "stmt_len": 48,
+    "stmt_location": 0
+    }
+},
+{
+    "RawStmt": {
+    "stmt": {
+        "IndexStmt": {
+        "idxname": "idx_composite",
+        "relation": {
+            "relname": "table_composite",
+            "inh": true,
+            "relpersistence": "p",
+            "location": 80
+        },
+        "accessMethod": "btree",
+        "indexParams": [
+            {
+            "IndexElem": {
+                "name": "col1",
+                "ordering": "SORTBY_DEFAULT",
+                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
+            }
+            },
+            {
+            "IndexElem": {
+                "name": "col2",
+                "ordering": "SORTBY_DEFAULT",
+                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
+            }
+            }
+        ]
+        }
+    },
+    "stmt_len": 59,
+    "stmt_location": 49
+    }
+},
+{
+    "RawStmt": {
+    "stmt": {
+        "IndexStmt": {
+        "idxname": "idx_include",
+        "relation": {
+            "relname": "table_include",
+            "inh": true,
+            "relpersistence": "p",
+            "location": 138
+        },
+        "accessMethod": "btree",
+        "indexParams": [
+            {
+            "IndexElem": {
+                "name": "col1",
+                "ordering": "SORTBY_DEFAULT",
+                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
+            }
+            }
+        ],
+        "indexIncludingParams": [
+            {
+            "IndexElem": {
+                "name": "col2",
+                "ordering": "SORTBY_DEFAULT",
+                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
+            }
+            },
+            {
+            "IndexElem": {
+                "name": "col3",
+                "ordering": "SORTBY_DEFAULT",
+                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
+            }
+            }
+        ]
+        }
+    },
+    "stmt_len": 70,
+    "stmt_location": 109
+    }
+},
+{
+    "RawStmt": {
+    "stmt": {
+        "IndexStmt": {
+        "idxname": "idx_CaseSimple",
+        "relation": {
+            "relname": "Table_CaseSimple",
+            "inh": true,
+            "relpersistence": "p",
+            "location": 214
+        },
+        "accessMethod": "btree",
+        "indexParams": [
+            {
+            "IndexElem": {
+                "name": "CaseSimple",
+                "ordering": "SORTBY_DEFAULT",
+                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
+            }
+            }
+        ]
+        }
+    },
+    "stmt_len": 67,
+    "stmt_location": 180
+    }
+},
+{
+    "RawStmt": {
+    "stmt": {
+        "IndexStmt": {
+        "idxname": "idx_CaseInclude",
+        "relation": {
+            "relname": "table_caseinclude",
+            "inh": true,
+            "relpersistence": "p",
+            "location": 283
+        },
+        "accessMethod": "btree",
+        "indexParams": [
+            {
+            "IndexElem": {
+                "name": "simple",
+                "ordering": "SORTBY_DEFAULT",
+                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
+            }
+            }
+        ],
+        "indexIncludingParams": [
+            {
+            "IndexElem": {
+                "name": "CaseInclude",
+                "ordering": "SORTBY_DEFAULT",
+                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
+            }
+            }
+        ]
+        }
+    },
+    "stmt_len": 85,
+    "stmt_location": 248
+    }
+}
+];

--- a/packages/ast/test/__tests__/expressions/__fixtures__/indexes.js
+++ b/packages/ast/test/__tests__/expressions/__fixtures__/indexes.js
@@ -1,169 +1,178 @@
 export const indexes = [
 {
-    "RawStmt": {
+  "RawStmt": {
     "stmt": {
-        "IndexStmt": {
-        "idxname": "idx_simple",
-        "relation": {
-            "relname": "table_simple",
-            "inh": true,
-            "relpersistence": "p",
-            "location": 27
-        },
-        "accessMethod": "btree",
-        "indexParams": [
-            {
-            "IndexElem": {
-                "name": "simple",
-                "ordering": "SORTBY_DEFAULT",
-                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
-            }
-            }
-        ]
-        }
-    },
-    "stmt_len": 48,
-    "stmt_location": 0
-    }
-},
-{
-    "RawStmt": {
-    "stmt": {
-        "IndexStmt": {
-        "idxname": "idx_composite",
-        "relation": {
-            "relname": "table_composite",
-            "inh": true,
-            "relpersistence": "p",
-            "location": 80
-        },
-        "accessMethod": "btree",
-        "indexParams": [
-            {
-            "IndexElem": {
-                "name": "col1",
-                "ordering": "SORTBY_DEFAULT",
-                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
-            }
-            },
-            {
-            "IndexElem": {
-                "name": "col2",
-                "ordering": "SORTBY_DEFAULT",
-                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
-            }
-            }
-        ]
-        }
-    },
-    "stmt_len": 59,
-    "stmt_location": 49
-    }
-},
-{
-    "RawStmt": {
-    "stmt": {
-        "IndexStmt": {
-        "idxname": "idx_include",
-        "relation": {
-            "relname": "table_include",
-            "inh": true,
-            "relpersistence": "p",
-            "location": 138
-        },
-        "accessMethod": "btree",
-        "indexParams": [
-            {
-            "IndexElem": {
-                "name": "col1",
-                "ordering": "SORTBY_DEFAULT",
-                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
-            }
-            }
-        ],
-        "indexIncludingParams": [
-            {
-            "IndexElem": {
-                "name": "col2",
-                "ordering": "SORTBY_DEFAULT",
-                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
-            }
-            },
-            {
-            "IndexElem": {
-                "name": "col3",
-                "ordering": "SORTBY_DEFAULT",
-                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
-            }
-            }
-        ]
-        }
-    },
-    "stmt_len": 70,
-    "stmt_location": 109
-    }
-},
-{
-    "RawStmt": {
-    "stmt": {
-        "IndexStmt": {
+      "IndexStmt": {
         "idxname": "idx_CaseSimple",
         "relation": {
-            "relname": "Table_CaseSimple",
-            "inh": true,
-            "relpersistence": "p",
-            "location": 214
+          "relname": "Table_CaseSimple",
+          "inh": true,
+          "relpersistence": "p",
+          "location": 33
         },
         "accessMethod": "btree",
         "indexParams": [
-            {
+          {
             "IndexElem": {
-                "name": "CaseSimple",
-                "ordering": "SORTBY_DEFAULT",
-                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
+              "name": "CaseSimple",
+              "ordering": "SORTBY_DEFAULT",
+              "nulls_ordering": "SORTBY_NULLS_DEFAULT"
             }
-            }
+          }
         ]
-        }
+      }
     },
-    "stmt_len": 67,
-    "stmt_location": 180
-    }
+    "stmt_len": 66,
+    "stmt_location": 0
+  }
 },
 {
-    "RawStmt": {
+  "RawStmt": {
     "stmt": {
-        "IndexStmt": {
-        "idxname": "idx_CaseInclude",
+      "IndexStmt": {
+        "idxname": "idx_CaseExpression",
         "relation": {
-            "relname": "table_caseinclude",
-            "inh": true,
-            "relpersistence": "p",
-            "location": 283
+          "relname": "Table_CaseExperssion",
+          "inh": true,
+          "relpersistence": "p",
+          "location": 106
         },
         "accessMethod": "btree",
         "indexParams": [
-            {
+          {
             "IndexElem": {
-                "name": "simple",
-                "ordering": "SORTBY_DEFAULT",
-                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
+              "expr": {
+                "FuncCall": {
+                  "funcname": [
+                    {
+                      "String": {
+                        "str": "lower"
+                      }
+                    }
+                  ],
+                  "args": [
+                    {
+                      "ColumnRef": {
+                        "fields": [
+                          {
+                            "String": {
+                              "str": "CaseSimple"
+                            }
+                          }
+                        ],
+                        "location": 136
+                      }
+                    }
+                  ],
+                  "location": 130
+                }
+              },
+              "ordering": "SORTBY_DEFAULT",
+              "nulls_ordering": "SORTBY_NULLS_DEFAULT"
             }
+          }
+        ]
+      }
+    },
+    "stmt_len": 83,
+    "stmt_location": 67
+  }
+},
+{
+  "RawStmt": {
+    "stmt": {
+      "IndexStmt": {
+        "idxname": "idx_CaseInclude",
+        "relation": {
+          "relname": "table_caseinclude",
+          "inh": true,
+          "relpersistence": "p",
+          "location": 187
+        },
+        "accessMethod": "btree",
+        "indexParams": [
+          {
+            "IndexElem": {
+              "name": "simple",
+              "ordering": "SORTBY_DEFAULT",
+              "nulls_ordering": "SORTBY_NULLS_DEFAULT"
             }
+          }
         ],
         "indexIncludingParams": [
-            {
+          {
             "IndexElem": {
-                "name": "CaseInclude",
-                "ordering": "SORTBY_DEFAULT",
-                "nulls_ordering": "SORTBY_NULLS_DEFAULT"
+              "name": "CaseInclude",
+              "ordering": "SORTBY_DEFAULT",
+              "nulls_ordering": "SORTBY_NULLS_DEFAULT"
             }
-            }
+          }
         ]
-        }
+      }
     },
-    "stmt_len": 85,
-    "stmt_location": 248
-    }
+    "stmt_len": 86,
+    "stmt_location": 151
+  }
+},
+{
+  "RawStmt": {
+    "stmt": {
+      "IndexStmt": {
+        "idxname": "idx_CaseIncludeExpr",
+        "relation": {
+          "relname": "table_caseincludeexpr",
+          "inh": true,
+          "relpersistence": "p",
+          "location": 277
+        },
+        "accessMethod": "btree",
+        "indexParams": [
+          {
+            "IndexElem": {
+              "name": "simple",
+              "ordering": "SORTBY_DEFAULT",
+              "nulls_ordering": "SORTBY_NULLS_DEFAULT"
+            }
+          }
+        ],
+        "indexIncludingParams": [
+          {
+            "IndexElem": {
+              "expr": {
+                "FuncCall": {
+                  "funcname": [
+                    {
+                      "String": {
+                        "str": "lower"
+                      }
+                    }
+                  ],
+                  "args": [
+                    {
+                      "ColumnRef": {
+                        "fields": [
+                          {
+                            "String": {
+                              "str": "CaseInclude"
+                            }
+                          }
+                        ],
+                        "location": 323
+                      }
+                    }
+                  ],
+                  "location": 317
+                }
+              },
+              "ordering": "SORTBY_DEFAULT",
+              "nulls_ordering": "SORTBY_NULLS_DEFAULT"
+            }
+          }
+        ]
+      }
+    },
+    "stmt_len": 100,
+    "stmt_location": 238
+  }
 }
 ];

--- a/packages/ast/test/__tests__/expressions/__snapshots__/indexes.test.js.snap
+++ b/packages/ast/test/__tests__/expressions/__snapshots__/indexes.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`index_stmt 1`] = `"CREATE INDEX idx_simple ON table_simple (simple);"`;
+
+exports[`index_stmt 2`] = `"CREATE INDEX idx_composite ON table_composite (col1, col2);"`;
+
+exports[`index_stmt 3`] = `"CREATE INDEX idx_include ON table_include (col1) INCLUDE (col2, col3);"`;
+
+exports[`index_stmt 4`] = `"CREATE INDEX \\"idx_CaseSimple\\" ON \\"Table_CaseSimple\\" (\\"CaseSimple\\");"`;
+
+exports[`index_stmt 5`] = `"CREATE INDEX \\"idx_CaseInclude\\" ON table_caseinclude (simple) INCLUDE (\\"CaseInclude\\");"`;

--- a/packages/ast/test/__tests__/expressions/__snapshots__/indexes.test.js.snap
+++ b/packages/ast/test/__tests__/expressions/__snapshots__/indexes.test.js.snap
@@ -1,11 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`index_stmt 1`] = `"CREATE INDEX idx_simple ON table_simple (simple);"`;
+exports[`index_stmt 1`] = `"CREATE INDEX \\"idx_CaseSimple\\" ON \\"Table_CaseSimple\\" (\\"CaseSimple\\");"`;
 
-exports[`index_stmt 2`] = `"CREATE INDEX idx_composite ON table_composite (col1, col2);"`;
+exports[`index_stmt 2`] = `"CREATE INDEX \\"idx_CaseExpression\\" ON \\"Table_CaseExperssion\\" (lower(\\"CaseSimple\\"));"`;
 
-exports[`index_stmt 3`] = `"CREATE INDEX idx_include ON table_include (col1) INCLUDE (col2, col3);"`;
+exports[`index_stmt 3`] = `"CREATE INDEX \\"idx_CaseInclude\\" ON table_caseinclude (simple) INCLUDE (\\"CaseInclude\\");"`;
 
-exports[`index_stmt 4`] = `"CREATE INDEX \\"idx_CaseSimple\\" ON \\"Table_CaseSimple\\" (\\"CaseSimple\\");"`;
-
-exports[`index_stmt 5`] = `"CREATE INDEX \\"idx_CaseInclude\\" ON table_caseinclude (simple) INCLUDE (\\"CaseInclude\\");"`;
+exports[`index_stmt 4`] = `"CREATE INDEX \\"idx_CaseIncludeExpr\\" ON table_caseincludeexpr (simple) INCLUDE (lower(\\"CaseInclude\\"));"`;

--- a/packages/ast/test/__tests__/expressions/indexes.test.js
+++ b/packages/ast/test/__tests__/expressions/indexes.test.js
@@ -1,0 +1,35 @@
+import { getConnections } from '../../utils';
+import { indexes } from './__fixtures__/indexes';
+
+let db, teardown;
+const objs = {
+  tables: {}
+};
+
+beforeAll(async () => {
+  ({ db, teardown } = await getConnections());
+  await db.begin();
+  await db.savepoint();
+});
+afterAll(async () => {
+  try {
+    //try catch here allows us to see the sql parsing issues!
+    await db.rollback();
+    await db.commit();
+    await teardown();
+  } catch (e) {}
+});
+
+it('index_stmt', async () => {
+    for (const index of indexes) {
+      const [{ deparse: result }] = await db.any(
+        `
+  select deparser.deparse(
+    $1::jsonb
+  );
+    `,
+        [index]
+      );
+      expect(result).toMatchSnapshot();
+    }
+  });


### PR DESCRIPTION
Hi!
I reviewed my previous #12 PR to understand where I screwed up.
Looks good now with entire test files (especialy `kitchen-sink.test.js` that I discovered)

Case sensitive columns names are now supported in IndexElem. Expressions were already handled.

Cheers, Florent